### PR TITLE
Add handling document number exceptions (RF passports)

### DIFF
--- a/Sources/MRZParser/Public/MRZParser.swift
+++ b/Sources/MRZParser/Public/MRZParser.swift
@@ -80,12 +80,15 @@ public struct MRZParser {
 
     private func makeDocumentNumberString(from mrzCode: MRZCode) -> String {
         var number = mrzCode.documentNumberField.value
+
+        // Exceptional condition for Russian national passport
         if mrzCode.documentTypeField.value == "PN"
             && mrzCode.countryCodeField.value == "RUS"
             && mrzCode.documentNumberField.value.count == 9,
             let hiddenDigit = mrzCode.optionalDataField.value.first {
             number.insert(hiddenDigit, at: number.index(number.startIndex, offsetBy: 3))
         }
+
         return number
     }
 }

--- a/Tests/MRZParserTests/MRZParserTests.swift
+++ b/Tests/MRZParserTests/MRZParserTests.swift
@@ -133,7 +133,7 @@ final class MRZParserTests: XCTestCase {
             countryCode: "RUS",
             surnames: "ZDRIL7K",
             givenNames: "SERGEQ ANATOL9EVI3",
-            documentNumber: "391935349",
+            documentNumber: "3914935349",
             nationalityCountryCode: "RUS",
             birthdate:  dateFormatter.date(from: "720723")!,
             sex: .male,


### PR DESCRIPTION
For RF passport MRZ code there is a hidden digit of document number located in optional data.
So to get correct passport number in the result we must take the digit from optional data (1st position) and insert it to extracted document number (4th position).

<img width="600" alt="image" src="https://user-images.githubusercontent.com/33960459/212296077-091c0e7b-fb82-40a2-912e-8165641be00a.png">
<img width="601" alt="image" src="https://user-images.githubusercontent.com/33960459/212296269-896dd18d-3c6f-406d-a53e-86f18368c0db.png">
