### PR TITLE
Add basic support for Dutch driving license (1-line MRZ fallback)

### DIFF
--- a/Tests/MRZParserTests/MRZCodeCreatorTests.swift
+++ b/Tests/MRZParserTests/MRZCodeCreatorTests.swift
@@ -56,6 +56,19 @@ final class MRZCodeCreatorTests: XCTestCase {
         case validateComposition(_ fields: [Field<String>], checkDigit: Int)
         case findMatchingStrings(_ strings: [String]?, _ isCorrectCombination: Bool)
     }
+    func testDutchSingleLine() {
+        let line = "D1NLD1234567890123456789012345"
+
+        let result = withDependencies {
+            $0.mrzCodeCreator = .liveValue
+        } operation: {
+            @Dependency(\.mrzCodeCreator) var creator
+            return creator.create([line], false)
+        }
+        XCTAssertNotNil(result, "MRZ parsing failed for valid Dutch license format")
+        XCTAssertEqual(result?.documentNumber, "123456789", "Document number mismatch")
+        XCTAssertEqual(result?.mrzKey, "123456789012345", "MRZ key mismatch")
+    }
 
     func testCreateNoFirstLine() {
         XCTAssertNil(


### PR DESCRIPTION
### Summary

This PR adds initial support for parsing Dutch driving licenses with a single-line MRZ (e.g., `D1NLD...`). It introduces a lightweight fallback path in `MRZCodeCreator` that recognizes the format and extracts:

- Document number
- Birthdate
- Expiry date

The fallback matches strings starting with `"D1NLD"` and of 30 characters in length.

### Why

The Dutch EU driving license MRZ does not follow ICAO TD1/TD2/TD3 standards and instead uses a 30-character one-line format. This MRZ is needed as a seed for NFC access (BAC key generation), and having this parsed correctly is a prerequisite for further feature development.

### Limitations & Future Work

- This is a pragmatic and minimal addition focused on enabling functionality quickly.
- It does **not** attempt to generalize to all EU driving licenses or introduce a new `MRZCode.Format` case like `.iso18013`, although that may be worth exploring later.
- The parsing logic is embedded as a fallback inside `MRZCodeCreator`, but a more modular and extensible approach (e.g., a plugin system or format-aware parsing strategy) would be cleaner.
- I’m very new to Swift and iOS codebases, so some parts may not follow best architectural practices — feedback and guidance are very welcome.

### Example

The following line will now return a valid `MRZCode`: D1NLD123456789001231250101ABCDE